### PR TITLE
Prevent ajax from using cached pages

### DIFF
--- a/401.html
+++ b/401.html
@@ -48,7 +48,7 @@
                                        <li class="nav-item"><a href="contact.html" id="ember512" class="nav-link ember-view">Contact</a></li>
                                        <li class="nav-item"><a href="faq.html" id="ember517" class="nav-link ember-view">FAQ</a></li>
                                        <li class="nav-item dropdown ml-auto">
-                                        <a href="/app/" id="ember510" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
+                                        <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                                       </li>                                    
                                    </ul>
                                  </div>

--- a/403.html
+++ b/403.html
@@ -48,7 +48,7 @@
                                        <li class="nav-item"><a href="contact.html" id="ember512" class="nav-link ember-view">Contact</a></li>
                                        <li class="nav-item"><a href="faq.html" id="ember517" class="nav-link ember-view">FAQ</a></li>
                                        <li class="nav-item dropdown ml-auto">
-                                        <a href="/app/" id="ember510" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
+                                        <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                                       </li>
                                     </ul>
                                  </div>

--- a/404.html
+++ b/404.html
@@ -48,7 +48,7 @@
                                        <li class="nav-item"><a href="contact.html" id="ember512" class="nav-link ember-view">Contact</a></li>
                                        <li class="nav-item"><a href="faq.html" id="ember517" class="nav-link ember-view">FAQ</a></li>
                                        <li class="nav-item dropdown ml-auto">
-                                        <a href="/app/" id="ember510" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
+                                        <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                                       </li>
                                     </ul>
                                  </div>

--- a/about.html
+++ b/about.html
@@ -53,7 +53,7 @@
                         <li class="nav-item"><a href="contact.html" id="ember512" class="nav-link ember-view">Contact</a></li>
                         <li class="nav-item"><a href="faq.html" id="ember517" class="nav-link ember-view">FAQ</a></li>
                         <li class="nav-item dropdown ml-auto" id="login-button">
-                          <a href="/app/" id="ember510" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
+                          <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                         </li>
                       </ul>
                     </div>

--- a/assets/logged-in.js
+++ b/assets/logged-in.js
@@ -1,5 +1,7 @@
   $(document).ready(function() {
-    $.ajax("/app/", {
+    $.ajax({
+      url: "/app/",
+      cache: false,
       success: function(data) {
         if (data.indexOf("<title>PASS</title>")>0) {
           var ul = document.getElementsByClassName("navbar-nav")[0].getElementsByTagName("li")[0];

--- a/assets/logged-in.js
+++ b/assets/logged-in.js
@@ -9,10 +9,21 @@
           $(ul).after('<li class="nav-item"><a href="/app/grants" class="nav-link ember-view">Grants</a></li>');
           var loginbtn = document.getElementById('login-button');
           loginbtn.style.visibility = 'hidden';
+        } else {
+          timestampLoginLink()
         }
       },
       error: function() {
-         //do nothing
+        timestampLoginLink()
       }
     });
   });
+  
+  function timestampLoginLink()  {
+    if ($('#login-link')) {
+      $('#login-link').attr('href',"/app/?_=" + new Date().getTime());
+    }
+    if ($('#get-started-link')) {
+      $('#get-started-link').attr('href',"/app/?_=" + new Date().getTime());
+    }
+  }

--- a/contact.html
+++ b/contact.html
@@ -51,7 +51,7 @@
                         <li class="nav-item"><a href="contact.html" id="ember512" class="nav-link ember-view">Contact</a></li>
                         <li class="nav-item"><a href="faq.html" id="ember517" class="nav-link ember-view">FAQ</a></li>
                         <li class="nav-item dropdown ml-auto" id="login-button">
-                          <a href="/app/" id="ember510" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
+                          <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                         </li>
                       </ul>
                     </div>

--- a/faq.html
+++ b/faq.html
@@ -49,7 +49,7 @@
                                        <li class="nav-item"><a href="contact.html" id="ember512" class="nav-link ember-view">Contact</a></li>
                                        <li class="nav-item"><a href="faq.html" id="ember517" class="nav-link ember-view">FAQ</a></li>
                                        <li class="nav-item dropdown ml-auto" id="login-button">
-                                        <a href="/app/" id="ember510" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
+                                        <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                                       </li>
                                     </ul>
                                  </div>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
                         <li class="nav-item"><a href="contact.html" id="ember438" class="nav-link ember-view">Contact</a></li>
                         <li class="nav-item"><a href="faq.html" id="ember443" class="nav-link ember-view">FAQ</a></li>
                         <li class="nav-item dropdown ml-auto" id="login-button">
-                          <a href="/app/" id="ember510" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
+                          <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                         </li>
                         <!--<li class="nav-item dropdown ml-auto">
                           <a data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" class="nav-link accountInfo pr-1">
@@ -173,7 +173,7 @@
                 publication open to the public, simultaneously send your manuscript to multiple repositories seamlessly, and populate forms automatically with publication and author information by providing DOIs and ORCID IDs. <a href="about.html"
                   id="ember653" class="ember-view">Learn more about PASS?</a>
               </p>
-              <a href="/app/" id="ember654" class="btn btn-primary mt-1 pl-4 pr-4 ember-view">Get started!</a>
+              <a href="/app/" id="get-started-link" class="btn btn-primary mt-1 pl-4 pr-4 ember-view">Get started!</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
ajax get js was using cached pages to determine login status. This forces it to use a non-cached page.

This also adds some javascript to the login check that will append a datetime stamp to /app/ login button links so that it does not use a cached /app/ page

### To test
1. Log into PASS. Go to Submissions
2. Log out. Close browser
3. Open browser go to PASS landing page
4. You should not see the Submissions and Grants links, you should see the Login button
