### PR TITLE
Changes to support branding

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,10 +6,11 @@
   <title>PASS</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link integrity="" rel="stylesheet" href="assets/pass-ember.css">
   <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="assets/coreUI.css">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
+  <link integrity="" rel="stylesheet" href="assets/pass-ember.css">
+  <link rel="stylesheet" href="assets/branding.css">
 </head>
 
 <body data-gr-c-s-loaded="true" class="ember-application">
@@ -21,38 +22,38 @@
   <div id="modal-overlays"></div>
   <div id="ember421" class="ember-view">
     <div style="z-index:0;" class="site">
-      <header class="primary-skin navbar navbar-expand-xs justify-content-center mb-0">
+      <header id="brand-header" class="navbar navbar-expand-xs justify-content-center mb-0">
         <div class="container">
-          <a href="index.html" id="ember449" class="navbar-brand custom-color d-none d-sm-block active ember-view">
-            <h3 class="font-weight-light">
-                        Public Access Submission System
-                     </h3>
+          <a href="index.html" class="navbar-brand d-none d-sm-block">
+            <h3 id="brand-header-title" class="font-weight-light">
+              Public Access Submission System
+            </h3>
           </a>
-          <a href="index.html" id="ember456" class="navbar-brand custom-color d-xs-block d-sm-none active ember-view">
+          <a href="index.html" class="navbar-brand custom-color d-xs-block d-sm-none active ember-view">
             <h3 class="font-weight-light">P.A.S.S.</h3>
           </a>
-          <img src="img/fullSizeLogo.png" alt="Logo" class="nav-item d-sm-down-none pull-right jhu-logo pr-0">
+          <a href="https://jhu.edu">
+            <img id="brand-logo" src="img/fullSizeLogo.png" alt="Logo" class="nav-item d-sm-down-none pull-right brand-logo pr-0">
+          </a>
         </div>
       </header>
       <div style="z-index:10000;">
-        <div id="ember457" class="sticky-element-container ember-view">
-          <div id="ember464" class="sticky-element__trigger sticky-element__trigger--top ember-view"></div>
-          <div class="
-                     sticky-element
-                     ">
-            <div id="ember469" class="ember-view">
-              <nav style="background: white;" id="myHeader" class="navbar navbar-light navbar-expand-md w-100">
+        <div id="ember371" class="sticky-element-container ember-view">
+          <div id="ember378" class="sticky-element__trigger sticky-element__trigger--top ember-view"></div>
+          <div class="sticky-element">
+            <div id="ember383" class="ember-view">
+              <nav id="header-navbar" class="navbar navbar-light navbar-expand-md w-100">
                 <div class="container">
                   <div style="width:100%;" class="col-xs-12">
                     <button type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation" class="navbar-toggler text-center border-none">
-                                 <span class="navbar-toggler-icon"></span>
-                                 </button>
+                      <span class="navbar-toggler-icon"></span>
+                    </button>
                     <div id="navbarSupportedContent" class="collapse navbar-collapse">
                       <ul style="width:100%" class="navbar-nav">
-                        <li class="nav-item"><a href="index.html" id="ember470" class="nav-link pl-0 ml-0 ember-view">Home</a></li>
-                        <li class="nav-item"><a href="about.html" id="ember507" class="nav-link ember-view">About</a></li>
-                        <li class="nav-item"><a href="contact.html" id="ember512" class="nav-link ember-view">Contact</a></li>
-                        <li class="nav-item"><a href="faq.html" id="ember517" class="nav-link ember-view">FAQ</a></li>
+                        <li class="nav-item"><a href="index.html" class="nav-link pl-0 ml-0 ember-view">Home</a></li>
+                        <li class="nav-item"><a href="about.html" class="nav-link ember-view">About</a></li>
+                        <li class="nav-item"><a href="contact.html" class="nav-link ember-view">Contact</a></li>
+                        <li class="nav-item"><a href="faq.html" class="nav-link ember-view">FAQ</a></li>
                         <li class="nav-item dropdown ml-auto" id="login-button">
                           <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                         </li>
@@ -63,7 +64,6 @@
               </nav>
             </div>
           </div>
-          <!---->
         </div>
       </div>
       <div class="container site-content">
@@ -95,7 +95,7 @@
               PASS was created by the Sheridan Libraries at Johns Hopkins University, in collaboration with the Harvard University Office for Scholarly Communication, the MIT Libraries, and with inspiration from Jeff Spies, formerly of the Center for Open Science.
             </p>
             <p>
-              PASS is an open source software project. We welcome collaboration opportunities with other institutions who share our goals. <a href="contact.html" id="ember676" class="ember-view">Contact our team</a> for more information, or take a look at
+              PASS is an open source software project. We welcome collaboration opportunities with other institutions who share our goals. <a href="contact.html" class="ember-view">Contact our team</a> for more information, or take a look at
               our code base, <a href="https://github.com/OA-PASS">available on GitHub</a>.
             </p>
           </div>
@@ -104,7 +104,7 @@
       <footer class="app-footer justify-content-center mt-3">
         <div class="text-center p-1">
           <small>Interested in making PASS even better? Want to have PASS for your institution?
-                 <a href="contact.html" id="ember449" class="ember-view">Contact us</a>!</small>
+          <a href="contact.html" class="ember-view">Contact us</a>!</small>
         </div>
       </footer>
     </div>

--- a/assets/branding.css
+++ b/assets/branding.css
@@ -1,0 +1,222 @@
+@import url('fonts.css');
+
+:root {
+  --jhu-bg-primary: white;
+
+  /* JHU Primary Colors */
+  --jhu-blue-spirit: #68ACE5;
+  --jhu-blue-heritage: #002D72;
+  --jhu-black: #31261D;
+
+  /* JHU Secondary Colors */
+  --jhu-secondary-1: #CF4520;
+  --jhu-secondary-2: #76232F;
+  --jhu-secondary-3: #A15A95;
+  --jhu-secondary-4: #009B77;
+  --jhu-secondary-5: #0072CE;
+  --jhu-secondary-6: #F1C400;
+
+  /* JHU Accent Colors */
+  --jhu-accent-1: #CBA052;
+  --jhu-accent-2: #FF9E1B;
+  --jhu-accent-3: #FF6900;
+  --jhu-accent-4: #9E5330;
+  --jhu-accent-5: #4F2C1D;
+  --jhu-accent-6: #E8927C;
+  --jhu-accent-7: #A6192E;
+  --jhu-accent-8: #51284F;
+  --jhu-accent-9: #A192B2;
+  --jhu-accent-10: #418FDE;
+  --jhu-accent-11: #86C8BC;
+  --jhu-accent-12: #286140;
+  --jhu-accent-13: #179949;
+
+  /* JHU Fonts */
+  --font-headline: quadon-regular, tahoma;
+  --font-subhead: quadon-regular, tahoma;
+  --font-bodycopy-accent: quadon-regular, tahoma;
+  --font-bodycopy: gentona-light, tahoma;
+
+  /* Other colors */
+  --btn-active-color: #C9C9C9;
+  --header-color: #4A484C;
+}
+
+/* ---------------- */
+/* .bg-main {
+  background-color: white;
+}
+.bg1 {
+  background-color: var(--jhu-blue-heritage);
+}
+.bg2 {
+  background-color: var(--jhu-blue-spirit);
+}
+.bg-primary {
+  background-color: var(--jhu-accent-10);
+}
+
+.text-white {
+  color: white;
+}
+.text-black {
+  color: var(--jhu-black);
+}
+.text-link {
+  color: var(--jhu-secondary-5);
+}
+.text-link:hover {
+  color: var(--jhu-accent-10);
+} */
+/* ---------------- */
+
+body {
+  font-family: var(--font-bodycopy);
+  color: var(--jhu-black);
+}
+h1, h2, h3, h4, h5 {
+  font-family: var(--font-headline);
+}
+h1, h2 {
+  color: var(--header-color);
+}
+a, .btn-link {
+  color: var(--jhu-secondary-5);
+}
+a:hover, .btn-link:hover {
+ color: var(--jhu-accent-10);
+}
+
+/* Buttons */
+.btn-primary {
+  background-color: var(--jhu-secondary-5);
+  border-color: var(--jhu-secondary-5);
+  color:white;
+}
+.btn-primary:hover {
+  background-color: var(--jhu-accent-10);
+  border-color: var(--jhu-accent-10);
+}
+/*
+ * This mess must be done in order to properly override Bootstrap styles for a clicked button
+ */
+.btn-primary:not(:disabled):not(.disabled):active {
+  background-color: var(--jhu-accent-10);
+  border-color: var(--jhu-accent-10);
+}
+
+.btn-outline-primary {
+  border-color: var(--jhu-secondary-5);
+  color: var(--jhu-secondary-5);
+}
+.btn-outline-primary:hover {
+  background-color: var(--jhu-secondary-5);
+  border-color: var(--jhu-secondary-5);
+}
+.btn-outline-primary:not(:disabled):not(.disabled):active {
+  background-color: var(--jhu-accent-10);
+  border-color: var(--jhu-accent-10);
+}
+
+.btn-danger	{
+  color: white;
+  background-color: var(--jhu-secondary-1);
+}
+.btn-danger:hover {
+  background-color: var(--jhu-accent-7);
+  border-color: var(--jhu-accent-7);
+}
+.btn-danger:not(:disabled):not(.disabled):active {
+  background-color: var(--jhu-accent-7);
+  border-color: var(--jhu-accent-7);
+}
+
+.btn {
+  font-size: 1em !important;
+}
+
+/* Header */
+#brand-site-container {
+  background-color: var(--jhu-bg-primary);
+  /* background-color: var(--jhu-blue-spirit); */
+}
+#brand-header {
+  background-color: var(--jhu-blue-heritage);
+  color: var(--jhu-blue-spirit);
+}
+#brand-header-title {
+  /* color: var(--jhu-blue-spirit); */
+  color: white;
+}
+#header-navbar {
+  font-family: var(--font-bodycopy);
+}
+#header-navbar .nav-item .active {
+  font-weight: bold;
+}
+#header-navbar .nav-link {
+  color: var(--jhu-black);
+}
+#user-menu {
+  color: var(--jhu-black);
+}
+#user-menu-title {
+  background-color: var(--jhu-secondary-5);
+  color: white;
+}
+#user-menu .dropdown-item:active {
+  background-color: var(--btn-active-color);
+}
+#brand-logo {
+  height: 110px;
+  margin-top: -10px;
+  margin-right: -35px;
+  margin-bottom: -10px;
+}
+
+/* Status icons */
+.manuscript-required>.fa-circle, .manuscript-required .fa-info-circle,
+.approval-requested>.fa-circle, .approval-requested .fa-info-circle,
+.changes-requested>.fa-circle, .changes-requested .fa-info-circle,
+.needs-attention>.fa-circle, .needs-attention .fa-info-circle,
+.stalled>.fa-circle, .stalled .fa-info-circle,
+.failed>.fa-circle, .failed .fa-info-circle,
+.rejected>.fa-circle, .rejected .fa-info-circle {
+  color: var(--jhu-secondary-6);
+}
+.cancelled>.fa-circle, .cancelled .fa-info-circle,
+.not-submitted>.fa-circle, .not-submitted .fa-info-circle {
+  color: var(--jhu-accent-10);
+}
+.submitted>.fa-circle, .submitted .fa-info-circle,
+.complete>.fa-circle, .complete .fa-info-circle {
+  color: var(--jhu-accent-11);
+}
+.draft>.fa-circle, .draft .fa-info-circle {
+  color: gray;
+}
+
+/* Submission workflow */
+#proxy-input-block {
+  background-color: var(--jhu-blue-spirit);
+  color: var(--jhu-black);
+}
+#on-behalf-of-block {
+  background-color: var(--jhu-blue-spirit);
+  color: var(--jhu-black);
+}
+
+th.table-header > i {
+  color: var(--jhu-black);
+  opacity: 0.8;
+}
+#grant-details-title .back-arrow, #submission-details-title .back-arrow {
+  color: var(--jhu-black);
+  opacity: 0.7;
+}
+#grant-details-title .back-arrow:hover,
+#submission-details-title .back-arrow:hover {
+  opacity: 0.5;
+}
+
+

--- a/assets/fonts.css
+++ b/assets/fonts.css
@@ -1,0 +1,16 @@
+@font-face {
+  font-family: "gentona-light";
+  src: url("../fonts/Gentona-Light.ttf");
+}
+@font-face {
+  font-family: "gentona-medium";
+  src: url("../fonts/Gentona-Medium.ttf");
+}
+@font-face {
+  font-family: "quadon-black";
+  src: url("../fonts/Quadon-Medium.ttf");
+}
+@font-face {
+  font-family: "quadon-regular";
+  src: url("../fonts/Quadon-Regular.ttf");
+}

--- a/assets/pass-ember.css
+++ b/assets/pass-ember.css
@@ -1,20 +1,3 @@
-
-@font-face {
-  font-family: "gentona-light";
-  src: url("../fonts/Gentona-Light.ttf");
-}
-@font-face {
-  font-family: "gentona-medium";
-  src: url("../fonts/Gentona-Medium.ttf");
-}
-@font-face {
-  font-family: "quadon-black";
-  src:url("../fonts/Quadon-Medium.ttf");
-}
-@font-face {
-  font-family: "quadon-regular";
-  src:url("../fonts/Quadon-Regular.ttf");
-}
 .ember-modal-dialog {
   z-index: 51;
   position: fixed; }
@@ -93,294 +76,26 @@
 .ember-basic-dropdown-content-wormhole-origin {
   display: inline; }
 
-.ember-power-select-dropdown * {
-  box-sizing: border-box; }
-
-.ember-power-select-trigger {
-  position: relative;
-  border-top: 1px solid #aaaaaa;
-  border-bottom: 1px solid #aaaaaa;
-  border-right: 1px solid #aaaaaa;
-  border-left: 1px solid #aaaaaa;
-  border-radius: 4px;
-  background-color: #ffffff;
-  line-height: 1.75;
-  overflow-x: hidden;
-  text-overflow: ellipsis;
-  min-height: 1.75em;
-  user-select: none;
-  -webkit-user-select: none;
-  color: inherit;
-  /* Minimum clearfix for modern browsers */ }
-  .ember-power-select-trigger:after {
-    content: "";
-    display: table;
-    clear: both; }
-
-.ember-power-select-trigger:focus,
-.ember-power-select-trigger--active {
-  border-top: 1px solid #aaaaaa;
-  border-bottom: 1px solid #aaaaaa;
-  border-right: 1px solid #aaaaaa;
-  border-left: 1px solid #aaaaaa;
-  box-shadow: none; }
-
-.ember-basic-dropdown-trigger--below.ember-power-select-trigger[aria-expanded="true"],
-.ember-basic-dropdown-trigger--in-place.ember-power-select-trigger[aria-expanded="true"] {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0; }
-
-.ember-basic-dropdown-trigger--above.ember-power-select-trigger[aria-expanded="true"] {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0; }
-
-.ember-power-select-placeholder {
-  color: #999999;
-  display: block;
-  overflow-x: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis; }
-
-.ember-power-select-status-icon {
-  position: absolute;
-  display: inline-block;
-  width: 0;
-  height: 0;
-  top: 0;
-  bottom: 0;
-  margin: auto;
-  border-style: solid;
-  border-width: 7px 4px 0 4px;
-  border-color: #aaaaaa transparent transparent transparent; }
-  .ember-basic-dropdown-trigger[aria-expanded="true"] .ember-power-select-status-icon {
-    transform: rotate(180deg); }
-
-.ember-power-select-clear-btn {
-  position: absolute;
-  cursor: pointer; }
-
-.ember-power-select-trigger-multiple-input {
-  font-family: inherit;
-  font-size: inherit;
-  border: none;
-  display: inline-block;
-  line-height: inherit;
-  -webkit-appearance: none;
-  outline: none;
-  padding: 0;
-  float: left;
-  background-color: transparent;
-  text-indent: 2px;
-  /* There's a browser bug where this selectos cannot be chained with commas */ }
-  .ember-power-select-trigger-multiple-input:disabled {
-    background-color: #eeeeee; }
-  .ember-power-select-trigger-multiple-input::placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-webkit-input-placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-moz-placeholder {
-    opacity: 1;
-    color: #999999; }
-  .ember-power-select-trigger-multiple-input::-ms-input-placeholder {
-    opacity: 1;
-    color: #999999; }
-
-.ember-power-select-multiple-options {
-  padding: 0;
-  margin: 0; }
-
-.ember-power-select-multiple-option {
-  border: 1px solid gray;
-  border-radius: 4px;
-  color: #333333;
-  background-color: #e4e4e4;
-  padding: 0 4px;
-  display: inline-block;
-  line-height: 1.45;
-  float: left;
-  margin: 2px 0 2px 3px; }
-
-.ember-power-select-multiple-remove-btn {
-  cursor: pointer; }
-  .ember-power-select-multiple-remove-btn:not(:hover) {
-    opacity: 0.5; }
-
-.ember-power-select-search {
-  padding: 4px; }
-
-.ember-power-select-search-input {
-  border: 1px solid #aaaaaa;
-  border-radius: 0;
-  width: 100%;
-  font-size: inherit;
-  line-height: inherit;
-  padding: 0 5px; }
-  .ember-power-select-search-input:focus {
-    border: 1px solid #aaaaaa;
-    box-shadow: none; }
-
-.ember-power-select-dropdown {
-  border-left: 1px solid #aaaaaa;
-  border-right: 1px solid #aaaaaa;
-  line-height: 1.75;
-  border-radius: 4px;
-  box-shadow: none;
-  overflow: hidden;
-  color: inherit; }
-
-.ember-power-select-dropdown.ember-basic-dropdown-content--above {
-  border-top: 1px solid #aaaaaa;
-  border-bottom: none;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0; }
-
-.ember-power-select-dropdown.ember-basic-dropdown-content--below, .ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
-  border-top: none;
-  border-bottom: 1px solid #aaaaaa;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0; }
-
-.ember-power-select-dropdown.ember-basic-dropdown-content--in-place {
-  width: 100%; }
-
-.ember-power-select-options {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  user-select: none;
-  -webkit-user-select: none; }
-  .ember-power-select-options[role="listbox"] {
-    overflow-y: auto;
-    /* in firefox in windows this can cause a word-break issue. Try `overflow-y: scroll` if that happens */
-    -webkit-overflow-scrolling: touch;
-    max-height: 12.25em; }
-
-.ember-power-select-option {
-  cursor: pointer;
-  padding: 0 8px; }
-
-.ember-power-select-group[aria-disabled="true"] {
-  color: #999999;
-  cursor: not-allowed; }
-
-.ember-power-select-group[aria-disabled="true"] .ember-power-select-option,
-.ember-power-select-option[aria-disabled="true"] {
-  color: #999999;
-  pointer-events: none;
-  cursor: not-allowed; }
-
-.ember-power-select-option[aria-selected="true"] {
-  background-color: #dddddd; }
-
-.ember-power-select-option[aria-current="true"] {
-  background-color: #5897fb;
-  color: #ffffff; }
-
-.ember-power-select-group-name {
-  cursor: default;
-  font-weight: bold; }
-
-.ember-power-select-trigger[aria-disabled=true] {
-  background-color: #eeeeee; }
-
-.ember-power-select-trigger {
-  padding: 0 16px 0 0; }
-
-.ember-power-select-selected-item, .ember-power-select-placeholder {
-  margin-left: 8px; }
-
-.ember-power-select-status-icon {
-  right: 5px; }
-
-.ember-power-select-clear-btn {
-  right: 25px; }
-
-.ember-power-select-group .ember-power-select-group .ember-power-select-group-name {
-  padding-left: 24px; }
-
-.ember-power-select-group .ember-power-select-group .ember-power-select-option {
-  padding-left: 40px; }
-
-.ember-power-select-group .ember-power-select-option {
-  padding-left: 24px; }
-
-.ember-power-select-group .ember-power-select-group-name {
-  padding-left: 8px; }
-
-.ember-power-select-trigger[dir=rtl] {
-  padding: 0 0 0 16px; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-selected-item, .ember-power-select-trigger[dir=rtl] .ember-power-select-placeholder {
-    margin-right: 8px; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-multiple-option {
-    float: right; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-trigger-multiple-input {
-    float: right; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-status-icon {
-    left: 5px;
-    right: initial; }
-  .ember-power-select-trigger[dir=rtl] .ember-power-select-clear-btn {
-    left: 25px;
-    right: initial; }
-
-.ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group .ember-power-select-group-name {
-  padding-right: 24px; }
-
-.ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group .ember-power-select-option {
-  padding-right: 40px; }
-
-.ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-option {
-  padding-right: 24px; }
-
-.ember-power-select-dropdown[dir=rtl] .ember-power-select-group .ember-power-select-group-name {
-  padding-right: 8px; }
-
 /* Override things with JHU rules */
-body {
-  background-color: #f5f4f3; }
-
-a {
-  color: #005EB8; }
-
-primary-skin {
-  background-color: #002D72 !important;
-  color: #fff !important; }
-
 header {
   margin-bottom: 24px; }
-  header .pass-title {
-    padding: 0; }
-    header .pass-title span {
-      font-size: 1.2em; }
-  header .navbar {
-    padding-top: 0; }
-  header .navbar-brand img {
-    width: 250px;
-    margin: 0 24px; }
-  header .navbar-dark .navbar-nav .nav-link {
-    padding: 0 1rem;
-    color: #68ACE5;
-    border-right: 1px solid #7E7E7C; }
-    header .navbar-dark .navbar-nav .nav-link:hover {
-      color: #E5E2E0; }
-    header .navbar-dark .navbar-nav .nav-link.borderless {
-      border: 0; }
-
-.nav-link:hover {
-  color: #B4B2AD; }
-
-.text-info {
-  color: #6399AE !important; }
-
-/* Buttons */
-.btn-outline-info {
-  color: #6399AE;
-  border-color: #6399AE; }
-  .btn-outline-info:hover {
-    color: #fff;
-    background-color: #6399AE;
-    border-collapse: #6399AE; }
+header .pass-title {
+  padding: 0; }
+header .pass-title span {
+  font-size: 1.2em; }
+header .navbar {
+  padding-top: 0; }
+header .navbar-brand img {
+  width: 250px;
+  margin: 0 24px; }
+header .navbar-dark .navbar-nav .nav-link {
+  padding: 0 1rem;
+  color: #68ACE5;
+  border-right: 1px solid #7E7E7C; }
+header .navbar-dark .navbar-nav .nav-link:hover {
+  color: #E5E2E0; }
+header .navbar-dark .navbar-nav .nav-link.borderless {
+  border: 0; }
 
 /* Tables */
 .table-bordered {
@@ -395,26 +110,8 @@ th.table-header > i {
 th.table-header > i:not(.fa-sort-asc):not(.fa-sort-desc) {
   font: normal normal normal 14px/1 FontAwesome;
   -webkit-font-smoothing: antialiased; }
-  th.table-header > i:not(.fa-sort-asc):not(.fa-sort-desc):before {
-    content: "\f0dc" !important; }
-
-.fa-arrow-left {
-  color: #ccc; }
-
-.models-table-wrapper .globalSearch span.input-group-addon {
-  margin-top: 0.2rem; }
-
-.models-table-wrapper .globalSearch .filterString {
-  height: 2rem;
-  width: 30rem;
-  max-width: 70%;
-  margin: 0 0 1em 12px; }
-
-.submission-details .row {
-  padding: 6px 0; }
-
-.submission-funders .row {
-  padding: 0; }
+th.table-header > i:not(.fa-sort-asc):not(.fa-sort-desc):before {
+  content: "\f0dc" !important; }
 
 .policies-list h6 {
   margin-bottom: .5em;
@@ -484,14 +181,6 @@ td {
   width: 30px;
   height: auto; }
 
-.custom-header {
-  background: url(https://image.ibb.co/gx84Uc/JHU.jpg) repeat-x 0 0;
-  text-align: center;
-  width: 100%;
-  height: 425px;
-  background-repeat: no-repeat;
-  background-size: cover; }
-
 .sticky {
   position: fixed;
   top: 0;
@@ -541,19 +230,6 @@ td {
 .modal-dialog {
   top: 30vh !important; }
 
-.file-description-width {
-  min-width: 250px !important; }
-
-.alpaca-invalid > input, .alpaca-invalid > textarea, .alpaca-invalid > select {
-  border-color: #f86c6b; }
-
-.alpaca-message-notOptional {
-  display: none; }
-
-.alpaca-required-indicator {
-  margin-left: 5px;
-  color: #777; }
-
 .glyphicon {
   font-family: "FontAwesome"; }
 
@@ -572,112 +248,27 @@ td {
 .glyphicon-info-sign:before {
   content: "\f05a"; }
 
-.alpaca-field-array .alpaca-container-label {
-  font-size: 1em !important; }
-
-.alpaca-array-actionbar-bottom {
-  margin-top: -25px; }
-
-.alpaca-array-actionbar-top {
-  float: right;
-  margin-right: -130px; }
-
-[data-alpaca-container-item-name*="authors_"] {
-  width: 100%; }
-
-[data-alpaca-container-item-name*="authors_"] > div > div:nth-child(2) > div {
-  width: 100%;
-  display: flex;
-  flex-direction: row; }
-
-[data-alpaca-container-item-name*="authors_"] > div > div:nth-child(2) > div > div:nth-child(odd) {
-  margin-right: 2px; }
-
-[data-alpaca-container-item-name*="authors_"] > div > div:nth-child(2) > div > div:nth-child(even) {
-  margin-left: 2px; }
-
-@media (max-width: 1200px) {
-  .alpaca-array-actionbar-top {
-    float: left;
-    margin-right: 0;
-    margin-bottom: 3px; }
-  [data-alpaca-container-item-name*="authors_"] > div > div:nth-child(2) > div {
-    width: 100%; } }
-
-.form-control:disabled, .form-control[readonly] {
-  background-color: #eff7fb !important; }
-
 body {
-  font-family: gentona-light, sans-serif !important;
   font-size: 1em !important;
-  color: #2C2C33 !important;
   -webkit-font-smoothing: antialiased;
   -moz-font-smoothing: antialiased;
-  -o-font-smoothing: antialiased; }
-
-h1, h2, h3, h4, h5 {
-  font-family: quadon-regular, serif !important; }
-
+  -o-font-smoothing: antialiased;
+}
 h1 {
-  font-size: 1.7rem !important; }
-
+  font-size: 1.7rem!important;
+}
 h2 {
-  font-size: 1.4rem !important; }
-
+  font-size: 1.4rem!important;
+}
 h3 {
-  font-size: 1.3rem !important; }
-
-a {
-  color: #005EB8 !important; }
-
-.navbar {
-  background: #005EB8; }
-
-.btn-primary {
-  background-color: #418FDE !important;
-  border-color: #418FDE !important;
-  color: white !important; }
-
-.btn-outline-primary {
-  border-color: #418FDE !important;
-  color: #418FDE !important; }
-
-.btn-outline-primary:hover {
-  background-color: #418FDE !important;
-  color: white !important; }
-
-.btn-danger {
-  color: white !important;
-  background-color: #f86c6b !important; }
-
-.badge-danger {
-  color: white !important;
-  background-color: #f86c6b !important; }
-
-.btn-link {
-  color: #418FDE !important; }
-
-.btn {
-  font-size: 1em !important; }
-
-.navbar-light .navbar-nav .nav-link, .navbar-light .navbar-nav .navbar .dropdown-toggle, .navbar .navbar-light .navbar-nav .dropdown-toggle {
-  color: #2C2C33 !important; }
-
-.navbar-light .navbar-nav .show > .nav-link, .navbar-light .navbar-nav .navbar .show > .dropdown-toggle, .navbar .navbar-light .navbar-nav .show > .dropdown-toggle, .navbar-light .navbar-nav .active > .nav-link, .navbar-light .navbar-nav .navbar .active > .dropdown-toggle, .navbar
-.navbar-light .navbar-nav .active > .dropdown-toggle, .navbar-light .navbar-nav .nav-link.show, .navbar-light .navbar-nav .navbar .show.dropdown-toggle, .navbar
-.navbar-light .navbar-nav .show.dropdown-toggle, .navbar-light .navbar-nav .nav-link.active, .navbar-light .navbar-nav .navbar .active.dropdown-toggle, .navbar
-.navbar-light .navbar-nav .active.dropdown-toggle {
-  font-weight: bold;
-  color: #4A484C !important; }
+  font-size: 1.3rem!important;
+}
 
 .jhu-logo {
   height: 110px;
   margin-top: -10px;
   margin-right: -35px;
   margin-bottom: -10px; }
-
-h1, h2 {
-  color: #4A484C !important; }
 
 .notice-triangle {
   color: #b0b0b0; }
@@ -707,30 +298,6 @@ table td {
 
 .container-fluid {
   max-width: 1300px; }
-
-.grant-table table th {
-  min-width: 100px;
-  font-size: 0.9em; }
-
-.grant-table table tbody tr td:nth-of-type(1) > div {
-  min-width: 200px;
-  max-width: 250px; }
-
-.grant-table table tbody tr td:nth-of-type(2) {
-  min-width: 150px;
-  max-width: 200px; }
-
-.submission-table table tbody tr td:nth-of-type(6) div,
-.submission-table table tbody tr td:nth-of-type(5) div,
-.submission-table table tbody tr td:nth-of-type(4) div {
-  width: 100px; }
-
-.submission-table table tbody tr td:nth-of-type(1) div {
-  min-width: 200px;
-  max-width: 350px; }
-
-.models-table-wrapper .input-group span.input-group-btn {
-  visibility: hidden; }
 
 [tooltip] {
   position: relative;
@@ -864,30 +431,6 @@ footer {
 .site {
   min-width: 300px; }
 
-.submission-table table th:nth-child(2) {
-  white-space: nowrap; }
-
-.repoid-cell {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  word-break: initial; }
-
-.title-column {
-  min-width: 400px; }
-
-.msid-column {
-  min-width: 145px; }
-
-.actions-column {
-  min-width: 125px; }
-
-.awardnum-column {
-  min-width: 125px; }
-
-.awardnum-funder-column {
-  min-width: 150px; }
- 
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
   #not-supported-box {
     visibility:visibile;
@@ -902,7 +445,7 @@ footer {
     visibility:hidden;
   }
 }
- 
+
 @supports (top:0) {
   #not-supported-box {
     visibility:hidden;

--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+  "assetsUri": "/",
+  "branding": {
+    "homepage": "https://jhu.edu",
+    "logo": "img/fullSizeLogo.png",
+    "stylesheet": "assets/branding.css"
+  }
+}

--- a/contact.html
+++ b/contact.html
@@ -6,51 +6,54 @@
   <title>PASS</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link integrity="" rel="stylesheet" href="assets/pass-ember.css">
   <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="assets/coreUI.css">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
+  <link integrity="" rel="stylesheet" href="assets/pass-ember.css">
+  <link rel="stylesheet" href="assets/branding.css">
 </head>
 
 <body data-gr-c-s-loaded="true" class="ember-application">
   <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="crossorigin="anonymous"></script>
   <script src="assets/logged-in.js"></script>
-  
+
   <div id="not-supported-box">PASS does not support Internet Explorer. Please use Chrome, Firefox, or Edge to open PASS.</div>
   <div id="ember-basic-dropdown-wormhole"></div>
   <div id="modal-overlays"></div>
-  <div id="ember421" class="ember-view">
+  <div class="ember-view">
     <div style="z-index:0;" class="site">
-      <header class="primary-skin navbar navbar-expand-xs justify-content-center mb-0">
+      <header id="brand-header" class="navbar navbar-expand-xs justify-content-center mb-0">
         <div class="container">
-          <a href="index.html" id="ember449" class="navbar-brand custom-color d-none d-sm-block active ember-view">
-            <h3 class="font-weight-light">
-                        Public Access Submission System
-                     </h3>
+          <a href="index.html" class="navbar-brand d-none d-sm-block">
+            <h3 id="brand-header-title" class="font-weight-light">
+              Public Access Submission System
+            </h3>
           </a>
-          <a href="index.html" id="ember456" class="navbar-brand custom-color d-xs-block d-sm-none active ember-view">
+          <a href="index.html" class="navbar-brand custom-color d-xs-block d-sm-none active ember-view">
             <h3 class="font-weight-light">P.A.S.S.</h3>
           </a>
-          <img src="img/fullSizeLogo.png" alt="Logo" class="nav-item d-sm-down-none pull-right jhu-logo pr-0">
+          <a href="https://jhu.edu">
+            <img id="brand-logo" src="img/fullSizeLogo.png" alt="Logo" class="nav-item d-sm-down-none pull-right brand-logo pr-0">
+          </a>
         </div>
       </header>
       <div style="z-index:10000;">
-        <div id="ember457" class="sticky-element-container ember-view">
-          <div id="ember464" class="sticky-element__trigger sticky-element__trigger--top ember-view"></div>
+        <div class="sticky-element-container ember-view">
+          <div class="sticky-element__trigger sticky-element__trigger--top ember-view"></div>
           <div class="sticky-element">
-            <div id="ember469" class="ember-view">
-              <nav style="background: white;" id="myHeader" class="navbar navbar-light navbar-expand-md w-100">
+            <div class="ember-view">
+              <nav id="header-navbar" class="navbar navbar-light navbar-expand-md w-100">
                 <div class="container">
                   <div style="width:100%;" class="col-xs-12">
                     <button type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation" class="navbar-toggler text-center border-none">
-                                 <span class="navbar-toggler-icon"></span>
-                                 </button>
+                      <span class="navbar-toggler-icon"></span>
+                    </button>
                     <div id="navbarSupportedContent" class="collapse navbar-collapse">
                       <ul style="width:100%" class="navbar-nav">
-                        <li class="nav-item"><a href="index.html" id="ember470" class="nav-link pl-0 ml-0 ember-view">Home</a></li>
-                        <li class="nav-item"><a href="about.html" id="ember507" class="nav-link ember-view">About</a></li>
-                        <li class="nav-item"><a href="contact.html" id="ember512" class="nav-link ember-view">Contact</a></li>
-                        <li class="nav-item"><a href="faq.html" id="ember517" class="nav-link ember-view">FAQ</a></li>
+                        <li class="nav-item"><a href="index.html" class="nav-link pl-0 ml-0 ember-view">Home</a></li>
+                        <li class="nav-item"><a href="about.html" class="nav-link ember-view">About</a></li>
+                        <li class="nav-item"><a href="contact.html" class="nav-link ember-view">Contact</a></li>
+                        <li class="nav-item"><a href="faq.html" class="nav-link ember-view">FAQ</a></li>
                         <li class="nav-item dropdown ml-auto" id="login-button">
                           <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                         </li>
@@ -61,7 +64,6 @@
               </nav>
             </div>
           </div>
-          <!---->
         </div>
       </div>
       <div class="container site-content">
@@ -102,7 +104,7 @@
       <footer class="app-footer justify-content-center mt-3">
         <div class="text-center p-1">
           <small>Interested in making PASS even better? Want to have PASS for your institution?
-                 <a href="contact.html" id="ember449" class="ember-view">Contact us</a>!</small>
+          <a href="contact.html" class="ember-view">Contact us</a>!</small>
         </div>
       </footer>
     </div>

--- a/faq.html
+++ b/faq.html
@@ -1,191 +1,245 @@
 <html lang="en" data-ember-extension="1" class="gr__localhost">
-   <head>
-      <meta charset="utf-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <title>PASS</title>
-      <meta name="description" content="">
-      <meta name="viewport" content="width=device-width, initial-scale=1">
-      <link integrity="" rel="stylesheet" href="assets/pass-ember.css">
-      <link rel="icon" href="favicon.png">
-      <link rel="stylesheet" href="assets/coreUI.css">
-      <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
-   </head>
-   <body data-gr-c-s-loaded="true" class="ember-application">
-      <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-      <script src="assets/logged-in.js"></script>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>PASS</title>
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="favicon.png">
+  <link rel="stylesheet" href="assets/coreUI.css">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
+  <link integrity="" rel="stylesheet" href="assets/pass-ember.css">
+  <link rel="stylesheet" href="assets/branding.css">
+</head>
 
-      <div id="not-supported-box">PASS does not support Internet Explorer. Please use Chrome, Firefox, or Edge to open PASS.</div>
-      <div id="ember-basic-dropdown-wormhole"></div>
-      <div id="modal-overlays"></div>
-      <div id="ember421" class="ember-view">
-         <div style="z-index:0;" class="site">
-            <header class="primary-skin navbar navbar-expand-xs justify-content-center mb-0">
-               <div class="container">
-                  <a href="index.html" id="ember449" class="navbar-brand custom-color d-none d-sm-block active ember-view">
-                     <h3 class="font-weight-light">
-                        Public Access Submission System
-                     </h3>
-                  </a>
-                  <a href="index.html" id="ember456" class="navbar-brand custom-color d-xs-block d-sm-none active ember-view">
-                     <h3 class="font-weight-light">P.A.S.S.</h3>
-                  </a>
-                  <img src="img/fullSizeLogo.png" alt="Logo" class="nav-item d-sm-down-none pull-right jhu-logo pr-0">
-               </div>
-            </header>
-            <div style="z-index:10000;">
-               <div id="ember457" class="sticky-element-container ember-view">
-                  <div id="ember464" class="sticky-element__trigger sticky-element__trigger--top ember-view"></div>
-                  <div class="sticky-element">
-                     <div id="ember469" class="ember-view">
-                        <nav style="background: white;" id="myHeader" class="navbar navbar-light navbar-expand-md w-100">
-                           <div class="container">
-                              <div style="width:100%;" class="col-xs-12">
-                                 <button type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation" class="navbar-toggler text-center border-none">
-                                 <span class="navbar-toggler-icon"></span>
-                                 </button>
-                                 <div id="navbarSupportedContent" class="collapse navbar-collapse">
-                                    <ul style="width:100%" class="navbar-nav">
-                                       <li class="nav-item"><a href="index.html" id="ember470" class="nav-link pl-0 ml-0 ember-view">Home</a></li>
-                                       <li class="nav-item"><a href="about.html" id="ember507" class="nav-link ember-view">About</a></li>
-                                       <li class="nav-item"><a href="contact.html" id="ember512" class="nav-link ember-view">Contact</a></li>
-                                       <li class="nav-item"><a href="faq.html" id="ember517" class="nav-link ember-view">FAQ</a></li>
-                                       <li class="nav-item dropdown ml-auto" id="login-button">
-                                        <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
-                                      </li>
-                                    </ul>
-                                 </div>
-                              </div>
-                           </div>
-                        </nav>
-                     </div>
+<body data-gr-c-s-loaded="true" class="ember-application">
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+  <script src="assets/logged-in.js"></script>
+
+  <div id="not-supported-box">PASS does not support Internet Explorer. Please use Chrome, Firefox, or Edge to open PASS.</div>
+  <div id="ember-basic-dropdown-wormhole"></div>
+  <div id="modal-overlays"></div>
+  <div class="ember-view">
+      <div style="z-index:0;" class="site">
+        <header id="brand-header" class="navbar navbar-expand-xs justify-content-center mb-0">
+          <div class="container">
+            <a href="index.html" class="navbar-brand d-none d-sm-block">
+              <h3 id="brand-header-title" class="font-weight-light">
+                Public Access Submission System
+              </h3>
+            </a>
+            <a href="index.html" class="navbar-brand custom-color d-xs-block d-sm-none active ember-view">
+              <h3 class="font-weight-light">P.A.S.S.</h3>
+            </a>
+            <a href="https://jhu.edu">
+              <img id="brand-logo" src="img/fullSizeLogo.png" alt="Logo" class="nav-item d-sm-down-none pull-right brand-logo pr-0">
+            </a>
+          </div>
+        </header>
+        <div style="z-index:10000;">
+          <div class="sticky-element-container ember-view">
+            <div class="sticky-element__trigger sticky-element__trigger--top ember-view"></div>
+            <div class="sticky-element">
+              <div class="ember-view">
+                <nav id="header-navbar" class="navbar navbar-light navbar-expand-md w-100">
+                  <div class="container">
+                    <div style="width:100%;" class="col-xs-12">
+                      <button type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation" class="navbar-toggler text-center border-none">
+                        <span class="navbar-toggler-icon"></span>
+                      </button>
+                      <div id="navbarSupportedContent" class="collapse navbar-collapse">
+                        <ul style="width:100%" class="navbar-nav">
+                          <li class="nav-item"><a href="index.html" class="nav-link pl-0 ml-0 ember-view">Home</a></li>
+                          <li class="nav-item"><a href="about.html" class="nav-link ember-view">About</a></li>
+                          <li class="nav-item"><a href="contact.html" class="nav-link ember-view">Contact</a></li>
+                          <li class="nav-item"><a href="faq.html" class="nav-link ember-view">FAQ</a></li>
+                          <li class="nav-item dropdown ml-auto" id="login-button">
+                            <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
                   </div>
-                  <!---->
-               </div>
-            </div>
-            <div class="container site-content">
-               <style>
-				.faq-content h3 {
-				  padding-top:10px;
-				  font-weight:bold;
-				  font-size: 1.2rem!important;
-				}
-				.integration-type-text {
-				  font-style: italic;
-				  margin-bottom:3px;
-				  padding-bottom:0;
-				}
-				.faq-anchor {
-				  display: block;
-				  position: relative;
-				  top: -50px;
-				  visibility: hidden;
-				}
-				</style>
-               <div style="max-width: 1000px;" class="ml-auto mr-auto faq-content">
-                 <header class="mt-5">
-                   <h1>Frequently Asked Questions</h1>
-                 </header>
-                 <p>The following questions are answered on this page. If you have other questions, feel free to <a href="contact.html" id="ember661" class="ember-view">contact us</a></p>
-                 <ul>
-                   <li><a href="#supported-policies">What Open or Public Access policies can PASS support?</a></li>
-                   <li><a href="#institution-policy">What is JHU's open access policy?</a></li>
-                   <li><a href="#what-to-expect">What should I expect after submitting through PASS?</a></li>
-                   <li><a href="#publisher-submit">Will the publisher automatically submit my article to PubMed Central?</a></li>
-                   <li><a href="#nih-submissions">What information about NIH submissions is pre-loaded into PASS?</a></li>
-                   <li><a href="#negotiate-copyright">How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</a></li>
-                   <li><a href="#who-can-use">Who can use PASS?</a></li>
-                 </ul>
-                 <section>
-                   <a id="supported-policies" class="faq-anchor"></a>
-                   <h3>What Open or Public Access policies can PASS support?</h3>
-                   <p>PASS supports Johns Hopkins University’s (JHU) Open Access policy by facilitating submission of an author’s accepted manuscripts to JScholarship, JHU’s institutional repository.</p>
-                   <p id="agencies_supported_by_PASS">Additionally, PASS supports existing workflows for federal funding agencies’ public access policy submission into PubMed Central (PMC) - used by NIH and the other funding agencies listed below:</p>
-                   <h5>Full integration</h5>
-                   <p class="integration-type-text">Programmatic submission from PASS to NIH Manuscript Submission System (NIHMS) and submission status updates</p>
-                   <ul>
-                     <li>NIH - National Institutes of Health</li>
-                   </ul>
-                   <h5>Deposit integration</h5>
-                   <p class="integration-type-text">Programmatic submission from PASS to NIHMS without submission status updates</p>
-                   <ul>
-                     <li>ACL - Administration for Community Living</li>
-                     <li>AHRQ - Agency for Healthcare Research and Quality</li>
-                     <li>ASPR – Office of the Assistant Secretary for Preparedness and Response</li>
-                     <li>CDC – Centers for Disease Control</li>
-                     <li>VA – Department of Veteran Affairs</li>
-                     <li>FDA - Food and Drug Administration</li>
-                     <li>HHMI- Howard Hughes Medical Institute</li>
-                     <li>NASA -National Aeronautics and Space Administration </li>
-                   </ul>
-                   <h5>Linked web portal</h5>
-                   <p class="integration-type-text">While programmatic integration is not currently possible, PASS does provide a link to these agencies’ submission portal and provides a list of relevant metadata to aid with submission process</p>
-                   <ul>
-                     <li>ED – Department of Education</li>
-                     <li>USAID – US Agency for International Development</li>
-                   </ul>
-                 </section>
-                 <section>
-                   <a id="institution-policy" class="faq-anchor"></a>
-                   <h3>What is JHU's open access policy?</h3>
-                   <p>As of July 1, 2018, Johns Hopkins University has implemented a university wide open access policy that expects  every scholarly article produced by full-time faculty members of Johns Hopkins University be accessible in an open access repository. To learn more about this policy visit the <a href="https://provost.jhu.edu/about/open-access/" target="_blank">Office of the Provost's webpages on Open Access at Johns Hopkins</a>.</p>
-                 </section>
-                 <section>
-                   <a id="what-to-expect" class="faq-anchor"></a>
-                   <h3>What should I expect after submitting through PASS?</h3>
-                   <p>Each submission may go through a different process for each repository. The PASS team will continue to work with funding agencies to improve integration with their repositories, and bring PASS users more convenient features and streamlined workflows. The current processes are described below:</p>
-                   <h5>PubMed Central (PMC)</h5>
-                   <p>Within a few hours of submitting your manuscript files to <a href="https://www.ncbi.nlm.nih.gov/pmc/" target="_blank">PubMed Central</a> through PASS, you will be contacted by the National Institutes of Health Manuscript Submission system (NIHMS) to approve the processing of the submission. At that point your submission will be assigned a NIHMSID, which can be used to demonstrate public access policy compliance while your submission is being processed.</p>
-                   <p>NIHMS staff will review the submission for completeness and accuracy. If any additional information is required, NIHMS will contact you to request changes. If no further information is required, the submission will be formatted for PMC publication.</p>
-                   <p>Once the processing stage is complete, you will be contacted again by NIHMS for final approval of the documents before publication in PMC. A PMCID will be assigned once the final approval has been received and the manuscript is matched to a PubMed record with complete citation information. The manuscript will then be made publicly available in PMC following the publisher-required embargo period, where applicable.</p>
-                   <p>For submissions citing an NIH grant for which you are or were the PI, PASS will be able to retrieve and display submissions, NIHMSID, and PMCID as they become available.</p>
-                   <p>You can read more about the NIHMS process in <a href="https://www.ncbi.nlm.nih.gov/books/NBK3846/" target="_blank">the NIHMS Help booklet on the NIH website</a>.</p>
-                   <h5>JScholarship</h5>
-                   <p>Manuscripts submitted to <a href="https://jscholarship.library.jhu.edu/" target="_blank">JScholarship</a> will be assigned an ID and link within several hours, which will be visible through PASS. The manuscript will also be publicly accessible within hours, or following any publisher-required embargo period, where applicable. Content within JScholarship is harvested and indexed by search engines such as Google.</p>
-                   <h5>Department of Education's ERIC Repository</h5>
-                   <p>PASS does not automatically create or track submissions to <a href="https://eric.ed.gov/" target="_blank">ERIC</a>, but it does identify manuscripts that are subject to the ED public access policy and provides a link to ERIC submission portal.</p>
-                   <h5>US Agency for International Development's DEC Repository</h5>
-                   <p>PASS does not automatically create or track submissions to <a href="https://dec.usaid.gov/" target="_blank">DEC</a>, but it does identify manuscripts that are subject to the USAID public access policy and provides a link to USAID submission portal.</p>
-                 </section>
-                 <section>
-                   <a id="publisher-submit" class="faq-anchor"></a>
-                   <h3>Will the publisher automatically submit my article to PubMed Central?</h3>
-                   <p>Whether articles are automatically submitted to PubMed Central by a publisher varies depending on the journal. Each journal falls into one of the following categories:</p>
-                   <ol>
-                     <li>The publisher can automatically submit the manuscript to PubMed Central on your behalf. A list of journals that provide this service can be <a href="https://publicaccess.nih.gov/submit_process_journals.htm" target="_blank">found here</a>. In this instance, nothing needs to be done through PASS.</li>
-                     <li>The publisher offers a service to submit the manuscript, but you need to make a special arrangement for them to do this and they may charge a processing fee.</li>
-                     <li>The publisher does not offer any service, and you must make your own arrangements to deposit the article. This would previously be done through the NIH Manuscript Submission system (NIHMS).</li>
-                   </ol>
-                   <p>When there is a fee or you must make your own arrangements, PASS can be used to submit the article to PubMed Central directly without fee. For more information on the various submission paths used by journals, visit the <a href="https://publicaccess.nih.gov/" target="_blank">NIH public access website.</a></p>
-                 </section>
-                 <section>
-                   <a id="nih-submissions" class="faq-anchor"></a>
-                   <h3>What information about NIH submissions is pre-loaded into PASS?</h3>
-                   <p>Records of prior NIH submissions displayed in PASS go back to January 2013. Each night, updated Submission information is loaded into PASS from the NIH Manuscript Submission system (NIHMS). This information contains the public access compliance status of articles associated with NIH grants. If you are a PI on an NIH grant and have articles that are associated with those grants in PubMed, you may see the following on <a href="/app/submissions" id="ember662" class="ember-view">your Submissions page</a>:</p>
-                      <ul>
-                        <li>Information about completed or in-progress Submissions, some of which may have been initiated outside of PASS. No action is required for these Submissions.</li>
-                        <li>Information about manuscripts that have not yet been received by NIH for deposit into PubMed Central. These will appear in PASS as "requiring a manuscript" and can be completed through PASS to deposit the manuscript into compliance.</li>
-                      </ul>
-                   <p>The information for these submissions comes directly from NIH. Please feel free to <a href="contact.html" id="ember663" class="ember-view">contact us</a> if there are problems with the information so that we can contact NIH.</p>
-                 </section>
-                 <section>
-                   <a id="negotiate-copyright" class="faq-anchor"></a>
-                   <h3>How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</h3>
-                   <p>Many journals make allowances for self-archiving and compliance with access policies implemented by a funder or institution. You can look up many publishers’ policies for copyright and self-archiving on the <a href="http://www.sherpa.ac.uk/romeo/index.php" target="_blank">SHERPA/RoMEO website</a>. If a journal does not allow open sharing of your article, you may be able to negotiate with them to make an exception. For help with copyright negotiation, or any other copyright related questions, please <a href="contact.html" id="ember664" class="ember-view">contact Robin Sinn at the Office of Scholarly Communication</a>.</p>
-                 </section>
-                 <section>
-                   <a id="who-can-use" class="faq-anchor"></a>
-                     <h3>Who can use PASS?</h3>
-                     <p>Anyone with valid Johns Hopkins login credentials can use PASS. This includes faculty, staff, students and other Johns Hopkins associates.</p>
-                 </section>
-               </div>
-            </div>
-            <footer class="app-footer justify-content-center mt-3">
-              <div class="text-center p-1">
-                <small>Interested in making PASS even better? Want to have PASS for your institution?
-                       <a href="contact.html" id="ember449" class="ember-view">Contact us</a>!</small>
+                </nav>
               </div>
-            </footer>
-         </div>
+            </div>
+          </div>
+        </div>
+        <div class="container site-content">
+        <style>
+          .faq-content h3 {
+            padding-top:10px;
+            font-weight:bold;
+            font-size: 1.2rem!important;
+          }
+          .integration-type-text {
+            font-style: italic;
+            margin-bottom:3px;
+            padding-bottom:0;
+          }
+          .faq-anchor {
+            display: block;
+            position: relative;
+            top: -50px;
+            visibility: hidden;
+          }
+        </style>
+        <div style="max-width: 1000px;" class="ml-auto mr-auto faq-content">
+          <header class="mt-5">
+            <h1>Frequently Asked Questions</h1>
+          </header>
+          <p>The following questions are answered on this page. If you have other questions, feel free to <a href="contact.html" class="ember-view">contact us</a></p>
+          <ul>
+            <li><a href="#supported-policies">What Open or Public Access policies can PASS support?</a></li>
+            <li><a href="#institution-policy">What is JHU's open access policy?</a></li>
+            <li><a href="#what-to-expect">What should I expect after submitting through PASS?</a></li>
+            <li><a href="#publisher-submit">Will the publisher automatically submit my article to PubMed Central?</a></li>
+            <li><a href="#nih-submissions">What information about NIH submissions is pre-loaded into PASS?</a></li>
+            <li><a href="#negotiate-copyright">How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</a></li>
+            <li><a href="#who-can-use">Who can use PASS?</a></li>
+          </ul>
+          <section>
+            <a id="supported-policies" class="faq-anchor"></a>
+            <h3>What Open or Public Access policies can PASS support?</h3>
+            <p>
+              PASS supports Johns Hopkins University’s (JHU) Open Access policy by facilitating submission of an author’s accepted manuscripts to JScholarship, JHU’s institutional repository.
+            </p>
+            <p id="agencies_supported_by_PASS">
+              Additionally, PASS supports existing workflows for federal funding agencies’ public access policy submission into PubMed Central (PMC) - used by NIH and the other funding agencies listed below:
+            </p>
+            <h5>Full integration</h5>
+            <p class="integration-type-text">Programmatic submission from PASS to NIH Manuscript Submission System (NIHMS) and submission status updates</p>
+            <ul>
+              <li>NIH - National Institutes of Health</li>
+            </ul>
+            <h5>Deposit integration</h5>
+            <p class="integration-type-text">Programmatic submission from PASS to NIHMS without submission status updates</p>
+            <ul>
+              <li>ACL - Administration for Community Living</li>
+              <li>AHRQ - Agency for Healthcare Research and Quality</li>
+              <li>ASPR – Office of the Assistant Secretary for Preparedness and Response</li>
+              <li>CDC – Centers for Disease Control</li>
+              <li>VA – Department of Veteran Affairs</li>
+              <li>FDA - Food and Drug Administration</li>
+              <li>HHMI- Howard Hughes Medical Institute</li>
+              <li>NASA -National Aeronautics and Space Administration </li>
+            </ul>
+            <h5>Linked web portal</h5>
+            <p class="integration-type-text">
+              While programmatic integration is not currently possible, PASS does provide a link to these agencies’ submission portal and provides a list of relevant metadata to aid with submission process
+            </p>
+            <ul>
+              <li>ED – Department of Education</li>
+              <li>USAID – US Agency for International Development</li>
+            </ul>
+          </section>
+          <section>
+            <a id="institution-policy" class="faq-anchor"></a>
+            <h3>What is JHU's open access policy?</h3>
+            <p>As of July 1, 2018, Johns Hopkins University has implemented a university wide open access policy that expects  every scholarly article produced by full-time faculty members of Johns Hopkins University be accessible in an open access repository. To learn more about this policy visit the <a href="https://provost.jhu.edu/about/open-access/" target="_blank">Office of the Provost's webpages on Open Access at Johns Hopkins</a>.</p>
+          </section>
+          <section>
+            <a id="what-to-expect" class="faq-anchor"></a>
+            <h3>What should I expect after submitting through PASS?</h3>
+            <p>
+              Each submission may go through a different process for each repository. The PASS team will continue to work with funding agencies to improve integration with their repositories,
+              and bring PASS users more convenient features and streamlined workflows. The current processes are described below:
+            </p>
+            <h5>PubMed Central (PMC)</h5>
+            <p>
+              Within a few hours of submitting your manuscript files to <a href="https://www.ncbi.nlm.nih.gov/pmc/" target="_blank">PubMed Central</a> through PASS, you will be contacted by the
+              National Institutes of Health Manuscript Submission system (NIHMS) to approve the processing of the submission. At that point your submission will be assigned a NIHMSID, which can be
+              used to demonstrate public access policy compliance while your submission is being processed.
+            </p>
+            <p>
+              NIHMS staff will review the submission for completeness and accuracy. If any additional information is required, NIHMS will contact you to request changes. If no further information
+              is required, the submission will be formatted for PMC publication.
+            </p>
+            <p>
+              Once the processing stage is complete, you will be contacted again by NIHMS for final approval of the documents before publication in PMC. A PMCID will be assigned once the final
+              approval has been received and the manuscript is matched to a PubMed record with complete citation information. The manuscript will then be made publicly available in PMC following
+              the publisher-required embargo period, where applicable.
+            </p>
+            <p>For submissions citing an NIH grant for which you are or were the PI, PASS will be able to retrieve and display submissions, NIHMSID, and PMCID as they become available.</p>
+            <p>You can read more about the NIHMS process in <a href="https://www.ncbi.nlm.nih.gov/books/NBK3846/" target="_blank">the NIHMS Help booklet on the NIH website</a>.</p>
+            <h5>JScholarship</h5>
+            <p>
+              Manuscripts submitted to <a href="https://jscholarship.library.jhu.edu/" target="_blank">JScholarship</a> will be assigned an ID and link within several hours, which will be visible
+              through PASS. The manuscript will also be publicly accessible within hours, or following any publisher-required embargo period, where applicable. Content within JScholarship is
+              harvested and indexed by search engines such as Google.
+            </p>
+            <h5>Department of Education's ERIC Repository</h5>
+            <p>
+              PASS does not automatically create or track submissions to <a href="https://eric.ed.gov/" target="_blank">ERIC</a>, but it does identify manuscripts that are subject to the ED public
+              access policy and provides a link to ERIC submission portal.
+            </p>
+            <h5>US Agency for International Development's DEC Repository</h5>
+            <p>
+              PASS does not automatically create or track submissions to <a href="https://dec.usaid.gov/" target="_blank">DEC</a>, but it does identify manuscripts that are subject to the USAID public
+              access policy and provides a link to USAID submission portal.
+            </p>
+          </section>
+          <section>
+            <a id="publisher-submit" class="faq-anchor"></a>
+            <h3>Will the publisher automatically submit my article to PubMed Central?</h3>
+            <p>Whether articles are automatically submitted to PubMed Central by a publisher varies depending on the journal. Each journal falls into one of the following categories:</p>
+            <ol>
+              <li>
+                The publisher can automatically submit the manuscript to PubMed Central on your behalf. A list of journals that provide this service can be
+                <a href="https://publicaccess.nih.gov/submit_process_journals.htm" target="_blank">found here</a>. In this instance, nothing needs to be done through PASS.
+              </li>
+              <li>The publisher offers a service to submit the manuscript, but you need to make a special arrangement for them to do this and they may charge a processing fee.</li>
+              <li>The publisher does not offer any service, and you must make your own arrangements to deposit the article. This would previously be done through the NIH Manuscript Submission system (NIHMS).</li>
+            </ol>
+            <p>
+              When there is a fee or you must make your own arrangements, PASS can be used to submit the article to PubMed Central directly without fee. For more information on the various submission paths
+              used by journals, visit the <a href="https://publicaccess.nih.gov/" target="_blank">NIH public access website.</a>
+            </p>
+          </section>
+          <section>
+            <a id="nih-submissions" class="faq-anchor"></a>
+            <h3>What information about NIH submissions is pre-loaded into PASS?</h3>
+            <p>
+              Records of prior NIH submissions displayed in PASS go back to January 2013. Each night, updated Submission information is loaded into PASS from the NIH Manuscript Submission system (NIHMS).
+              This information contains the public access compliance status of articles associated with NIH grants. If you are a PI on an NIH grant and have articles that are associated with those grants in
+              PubMed, you may see the following on <a href="/app/submissions" class="ember-view">your Submissions page</a>:
+            </p>
+            <ul>
+              <li>Information about completed or in-progress Submissions, some of which may have been initiated outside of PASS. No action is required for these Submissions.</li>
+              <li>
+                Information about manuscripts that have not yet been received by NIH for deposit into PubMed Central. These will appear in PASS as "requiring a manuscript" and can be completed through PASS
+                to deposit the manuscript into compliance.
+              </li>
+            </ul>
+            <p>
+              The information for these submissions comes directly from NIH. Please feel free to <a href="contact.html" class="ember-view">contact us</a> if there are problems with the information so that
+              we can contact NIH.
+            </p>
+          </section>
+          <section>
+            <a id="negotiate-copyright" class="faq-anchor"></a>
+            <h3>How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</h3>
+            <p>
+              Many journals make allowances for self-archiving and compliance with access policies implemented by a funder or institution. You can look up many publishers’ policies for copyright and
+              self-archiving on the <a href="http://www.sherpa.ac.uk/romeo/index.php" target="_blank">SHERPA/RoMEO website</a>. If a journal does not allow open sharing of your article, you may be able
+              to negotiate with them to make an exception. For help with copyright negotiation, or any other copyright related questions, please <a href="contact.html" class="ember-view">contact Robin Sinn
+                at the Office of Scholarly Communication</a>.
+            </p>
+          </section>
+          <section>
+            <a id="who-can-use" class="faq-anchor"></a>
+            <h3>Who can use PASS?</h3>
+            <p>Anyone with valid Johns Hopkins login credentials can use PASS. This includes faculty, staff, students and other Johns Hopkins associates.</p>
+          </section>
+        </div>
       </div>
-   </body>
+      <footer class="app-footer justify-content-center mt-3">
+        <div class="text-center p-1">
+          <small>Interested in making PASS even better? Want to have PASS for your institution?
+          <a href="contact.html" class="ember-view">Contact us</a>!</small>
+        </div>
+      </footer>
+    </div>
+  </div>
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,10 +6,11 @@
   <title>PASS</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link integrity="" rel="stylesheet" href="assets/pass-ember.css">
   <link rel="icon" href="favicon.png">
   <link rel="stylesheet" href="assets/coreUI.css">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
+  <link integrity="" rel="stylesheet" href="assets/pass-ember.css">
+  <link rel="stylesheet" href="assets/branding.css">
 </head>
 
 <body data-gr-c-s-loaded="true" class="ember-application">
@@ -23,56 +24,43 @@
 
   <div id="ember-basic-dropdown-wormhole"></div>
   <div id="modal-overlays"></div>
-  <div id="ember335" class="ember-view">
+  <div class="ember-view">
     <div style="z-index:0;" class="site">
-      <header class="primary-skin navbar navbar-expand-xs justify-content-center mb-0">
+      <header id="brand-header" class="navbar navbar-expand-xs justify-content-center mb-0">
         <div class="container">
-          <a href="index.html" id="ember363" class="navbar-brand custom-color d-none d-sm-block active ember-view">
-            <h3 class="font-weight-light">
-                       Public Access Submission System
-                    </h3>
+          <a href="index.html" class="navbar-brand d-none d-sm-block">
+            <h3 id="brand-header-title" class="font-weight-light">
+              Public Access Submission System
+            </h3>
           </a>
-          <a href="index.html" id="ember370" class="navbar-brand custom-color d-xs-block d-sm-none active ember-view">
+          <a href="index.html" class="navbar-brand custom-color d-xs-block d-sm-none active ember-view">
             <h3 class="font-weight-light">P.A.S.S.</h3>
           </a>
-          <a href="https://jhu.edu"><img src="img/fullSizeLogo.png" alt="Logo" class="nav-item d-sm-down-none pull-right jhu-logo pr-0"></a>
+          <a href="https://jhu.edu">
+            <img id="brand-logo" src="img/fullSizeLogo.png" alt="Logo" class="nav-item d-sm-down-none pull-right brand-logo pr-0">
+          </a>
         </div>
       </header>
       <div style="z-index:10000;">
-        <div id="ember371" class="sticky-element-container ember-view">
-          <div id="ember378" class="sticky-element__trigger sticky-element__trigger--top ember-view"></div>
-          <div class="
-                    sticky-element
-                    ">
-            <div id="ember383" class="ember-view">
-              <nav style="background: white;" id="myHeader" class="navbar navbar-light navbar-expand-md w-100">
+        <div class="sticky-element-container ember-view">
+          <div class="sticky-element__trigger sticky-element__trigger--top ember-view"></div>
+          <div class="sticky-element">
+            <div class="ember-view">
+              <nav id="header-navbar" class="navbar navbar-light navbar-expand-md w-100">
                 <div class="container">
                   <div style="width:100%;" class="col-xs-12">
                     <button type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation" class="navbar-toggler text-center border-none">
-                                <span class="navbar-toggler-icon"></span>
-                                </button>
+                      <span class="navbar-toggler-icon"></span>
+                    </button>
                     <div id="navbarSupportedContent" class="collapse navbar-collapse">
                       <ul style="width:100%" class="navbar-nav">
-                        <li class="nav-item"><a href="index.html" id="ember388" class="nav-link pl-0 ml-0 ember-view">Home</a></li>
-                        <li class="nav-item"><a href="about.html" id="ember433" class="nav-link ember-view">About</a></li>
-                        <li class="nav-item"><a href="contact.html" id="ember438" class="nav-link ember-view">Contact</a></li>
-                        <li class="nav-item"><a href="faq.html" id="ember443" class="nav-link ember-view">FAQ</a></li>
+                        <li class="nav-item"><a href="index.html" class="nav-link pl-0 ml-0 ember-view">Home</a></li>
+                        <li class="nav-item"><a href="about.html" class="nav-link ember-view">About</a></li>
+                        <li class="nav-item"><a href="contact.html" class="nav-link ember-view">Contact</a></li>
+                        <li class="nav-item"><a href="faq.html" class="nav-link ember-view">FAQ</a></li>
                         <li class="nav-item dropdown ml-auto" id="login-button">
                           <a href="/app/" id="login-link" class="dropdown-item btn btn-primary active ember-view"><i class="fa fa-lock"></i>Login</a>
                         </li>
-                        <!--<li class="nav-item dropdown ml-auto">
-                          <a data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" class="nav-link accountInfo pr-1">
-                                         <span class="pr-1"><img width="30" height="30" title="nihuser@jhu.edu" alt="nihuser@jhu.edu" src="https://www.gravatar.com/avatar/979678d4529fb62a12251478bb1fab7b?s=60&amp;d=identicon" id="ember444" class="img-avatar gravatar-image ember-view">
-                                         </span>
-                                         </a> 
-                          <div class="dropdown-menu dropdown-menu-right">
-                            <div class="dropdown-header text-center">
-                              <strong>Account</strong>
-                            </div>
-                            <div class="divider"></div>
-                            <a href="#" class="dropdown-item" data-ember-action="" data-ember-action-445="445"><i class="fa fa-lock"></i>Logout</a>
-                          </div>
-                        </li>-->
                       </ul>
                     </div>
                   </div>
@@ -80,31 +68,15 @@
               </nav>
             </div>
           </div>
-          <!---->
         </div>
       </div>
       <div class="container site-content">
-
         <!---->
         <style>
-          #headerCarousel {
-            width: 100%;
-          }
-
-          #headerCarousel .carouselInner {
-            width: 100%;
-          }
-
-          #headerCarousel .carousel-item {
-            width: 100%;
-            overflow: hidden;
-          }
-
-          #headerCarousel .carousel-item img {
-            height: 350px;
-            object-fit: cover;
-            min-width: auto;
-          }
+          #headerCarousel { width: 100%; }
+          #headerCarousel .carouselInner { width: 100%; }
+          #headerCarousel .carousel-item { width: 100%; overflow: hidden; }
+          #headerCarousel .carousel-item img { height: 350px; object-fit: cover; min-width: auto; }
         </style>
         <div>
           <div id="headerCarousel" data-ride="carousel" data-interval="5000" class="carousel slide">
@@ -171,18 +143,20 @@
             <div class="col-md-12 text-center">
               <h1 class="font-weight-light mt-4">Public Access Submission System</h1>
               <p class="font-weight-light mt-4">
-                Use PASS to submit your manuscripts to funder and institutional publication repositories (e.g. PubMed Central, JScholarship) and comply with access policies. Using the web-based PASS system, you can: avoid paying article processing charges to make your
-                publication open to the public, simultaneously send your manuscript to multiple repositories seamlessly, and populate forms automatically with publication and author information by providing DOIs and ORCID IDs. <a href="about.html"
-                  id="ember653" class="ember-view">Learn more about PASS?</a>
+                Use PASS to submit your manuscripts to funder and institutional publication repositories (e.g. PubMed Central, JScholarship)
+                and comply with access policies. Using the web-based PASS system, you can: avoid paying article processing charges to make your
+                publication open to the public, simultaneously send your manuscript to multiple repositories seamlessly, and populate forms
+                automatically with publication and author information by providing DOIs and ORCID IDs.
+                <a href="about.html" class="ember-view">Learn more about PASS?</a>
               </p>
               <a href="/app/" id="get-started-link" class="btn btn-primary mt-1 pl-4 pr-4 ember-view">Get started!</a>
             </div>
           </div>
         </div>
         <h2 class="font-weight-light mt-4 text-center m-4">
-               PASS supports existing submission workflows for the following agencies and institutions
-             </h2>
-        <div id="ember655" class="row mb-4 padding-lr-100 ember-view">
+          PASS supports existing submission workflows for the following agencies and institutions
+        </h2>
+        <div class="row mb-4 padding-lr-100 ember-view">
           <div class="col-md-6 col-lg-3">
             <div id="slideOne" data-interval="5000" data-ride="carousel" class="carousel slide auto">
               <ol class="carousel-indicators">
@@ -299,7 +273,7 @@
       <footer class="app-footer justify-content-center mt-3">
         <div class="text-center p-1">
           <small>Interested in making PASS even better? Want to have PASS for your institution?
-                 <a href="contact.html" id="ember449" class="ember-view">Contact us</a>!</small>
+          <a href="contact.html" class="ember-view">Contact us</a>!</small>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
The static HTML pages should render find if integrated immediately, but this would break some styling of the Ember app. I recommend merging these changes into `master` to get a solid commit that can be used in `pass-docker` and `pass-ember`.

* Many changes were made to bring static pages structurally in line with the rendered pages in the Ember app
* Various IDs and class names defined for some important HTML elements throughout the UI to try to help with styling
* Separate `branding.css` added focusing on a simplified set of rules for applying colors, fonts, etc
* Add `config.json` to let the Ember app know where various assets are
