### PR TITLE
DRAFT: Temporarily remove COVID entry in FAQ

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -98,7 +98,7 @@
             <li><a href="#negotiate-copyright">How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</a></li>
             <li><a href="#who-can-use">Who can use PASS?</a></li>
             <li><a href="#grants-expected">Which grants should I expect to see in PASS?</a></li>
-            <li><a href="#covid-19">How are submissions of COVID-19 manuscripts treated differently than other manuscripts?</a></li>
+            <!-- <li><a href="#covid-19">How are submissions of COVID-19 manuscripts treated differently than other manuscripts?</a></li> -->
           </ul>
           <section>
             <a id="supported-policies" class="faq-anchor"></a>
@@ -240,12 +240,12 @@
               PI, or Co-PI, or CO-I. If you find any issue with these grant records, please <a href="contact.html">contact us</a>.
             </p>
           </section>
-          <section>
+          <!-- <section>
             <h3 id="covid-19">How are submissions of COVID-19 manuscripts treated differently than other manuscripts?</h3>
             <p>
               Integer sollicitudin, arcu a mollis efficitur, tellus quam accumsan nibh, at consectetur arcu odio sed enim. Vestibulum quis lacinia massa. In sollicitudin felis eros, eu volutpat est facilisis nec. Donec sed purus at sem varius volutpat. Maecenas in sodales mauris. Duis sodales nisl a turpis semper porta sed in dolor. Mauris facilisis blandit vehicula. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla pharetra pharetra fermentum.
             </p>
-          </section>
+          </section> -->
         </div>
       </div>
       <footer class="app-footer justify-content-center mt-3">


### PR DESCRIPTION
We can use this if we don't text for the COVID entry in the FAQ. Will keep this as a draft until a new image needs to be cut, then either update the FAQ and remove this PR, or merge this.